### PR TITLE
Add quantized add operator for getting started tutorial

### DIFF
--- a/utensor_cgen/operators.py
+++ b/utensor_cgen/operators.py
@@ -131,6 +131,7 @@ class OperatorFactory():
                 "Dequantize": _DequantizeOperator,
                 "Max": _MaxOperator,
                 "Min": _MinOperator,
+                "QuantizedAdd", _AddOperator,
                 "QuantizeV2": _QuantizeV2Operator,
                 "QuantizedMatMul": _QuantizedMatMulOperator,
                 "QuantizedRelu": _QuantizedReluOperator,


### PR DESCRIPTION
This is needed for the tutorial. Quantized add can be added like this temporarily and fully implemented later. 

Works with utensor-mnist-demo