### PR TITLE
fix TypeError in TransformerPipeline tests

### DIFF
--- a/tests/test_transformer/test_pipeline/test_pipeline_transformer.py
+++ b/tests/test_transformer/test_pipeline/test_pipeline_transformer.py
@@ -3,19 +3,19 @@ from utensor_cgen.transformer import TransformerPipeline
 
 # three random tests
 def test_pipeline_1(methods):
-    pipeline = TransformerPipeline(methods, {})
+    pipeline = TransformerPipeline([(method, {}) for method in methods])
     assert len(pipeline.pipeline) == len(methods)
     for transformer, method_name in zip(pipeline.pipeline, methods):
         assert isinstance(transformer, pipeline._TRANSFORMER_MAP[method_name])
 
 def test_pipeline_2(methods):
-    pipeline = TransformerPipeline(methods, {})
+    pipeline = TransformerPipeline([(method, {}) for method in methods])
     assert len(pipeline.pipeline) == len(methods)
     for transformer, method_name in zip(pipeline.pipeline, methods):
         assert isinstance(transformer, pipeline._TRANSFORMER_MAP[method_name])
 
 def test_pipeline_3(methods):
-    pipeline = TransformerPipeline(methods, {})
+    pipeline = TransformerPipeline([(method, {}) for method in methods])
     assert len(pipeline.pipeline) == len(methods)
     for transformer, method_name in zip(pipeline.pipeline, methods):
         assert isinstance(transformer, pipeline._TRANSFORMER_MAP[method_name])


### PR DESCRIPTION
This patch fixes the following failures.

_______________________________ test_pipeline_1 ________________________________

methods = ['quantize', 'dropout', 'refcnt', 'batch_norm']

    def test_pipeline_1(methods):
>       pipeline = TransformerPipeline(methods, {})
E       TypeError: __init__() takes 2 positional arguments but 3 were given

tests/test_transformer/test_pipeline/test_pipeline_transformer.py:6: TypeError
_______________________________ test_pipeline_2 ________________________________

methods = ['quantize', 'dropout', 'batch_norm', 'refcnt']

    def test_pipeline_2(methods):
>       pipeline = TransformerPipeline(methods, {})
E       TypeError: __init__() takes 2 positional arguments but 3 were given

tests/test_transformer/test_pipeline/test_pipeline_transformer.py:12: TypeError
_______________________________ test_pipeline_3 ________________________________

methods = ['dropout', 'quantize', 'refcnt', 'batch_norm']

    def test_pipeline_3(methods):
>       pipeline = TransformerPipeline(methods, {})
E       TypeError: __init__() takes 2 positional arguments but 3 were given

tests/test_transformer/test_pipeline/test_pipeline_transformer.py:18: TypeError