### PR TITLE
Fix snippet typo and template

### DIFF
--- a/utensor_cgen/backend/operators.py
+++ b/utensor_cgen/backend/operators.py
@@ -443,7 +443,7 @@ class _Conv2DOperator(_Operator):
                                     op_info.op_attr)
     ref_count = parser.get('ref_counts', [0])[0]
     to_eval = parser.get('to_eval', False)
-    self._snippet = Conv2DOpSnippent(inputs, output, strides, padding,
+    self._snippet = Conv2DOpSnippet(inputs, output, strides, padding,
                                      in_dtype=in_dtype, filter_dtype=filter_dtype, out_dtype=out_dtype,
                                      ref_count=ref_count, to_eval=to_eval)
 @OperatorFactory.register
@@ -510,7 +510,7 @@ class _Conv2DQuantOperator(_Operator):
                                     op_info.op_attr)
     ref_counts = parser.get('ref_counts', [])
     to_eval = parser.get('to_eval', False)
-    self._snippet = Conv2DQuantOpSnippent(inputs, outputs, strides, padding,
+    self._snippet = Conv2DQuantOpSnippet(inputs, outputs, strides, padding,
                                      in_dtype=in_dtype, filter_dtype=filter_dtype, out_dtypes=out_dtypes,
                                      ref_counts=ref_counts, to_eval=to_eval)
 @OperatorFactory.register

--- a/utensor_cgen/backend/snippets/_snippets.py
+++ b/utensor_cgen/backend/snippets/_snippets.py
@@ -666,7 +666,7 @@ class FusedConv2DOpMaxpoolSnippet(Snippet):
     self.template_vars["to_eval"] = to_eval
 
 class QuantizedFusedConv2DOpMaxpoolSnippet(Snippet):
-  __template_name__ = "snippets/fused_conv2d_maxpool_op.cpp"
+  __template_name__ = "snippets/quantized_fused_conv2d_maxpool_op.cpp"
   __headers__ = set(['"uTensor/ops/MatrixOps.hpp"'])
 
   def __init__(self, inputs, output, strides, ksize, padding,

--- a/utensor_cgen/backend/snippets/_snippets.py
+++ b/utensor_cgen/backend/snippets/_snippets.py
@@ -13,7 +13,7 @@ __all__ = ["Snippet", "SnippetContainerBase",
            "ReluOpSnippet", "QuantizedReluOpSnippet", "ShapeOpSnippet",
            "StridedSliceOpSnippet", "PackOpSnippet", "SoftmaxOpSnippet",
            "ReshapeOpSnippet", "QuantizedReshapeOpSnippet",
-           "Conv2DOpSnippent", "Conv2DQuantOpSnippent", "CMSISNNFCOpSnippet",
+           "Conv2DOpSnippet", "Conv2DQuantOpSnippet", "CMSISNNFCOpSnippet",
            "RequantizationRangeOpSnippet", "RequantizeOpSnippet",
            "CommentSnippet", "ContextHeaderSnippet",
            "ContextSnippetsContainer", "QuantizedAddOpSnippet",
@@ -624,7 +624,7 @@ class CMSISNNFCOpSnippet(Snippet):
     self.template_vars["out_dtype"] = NP_TYPES_MAP[out_dtype].tensor_type_str
     self.template_vars["to_eval"] = to_eval
 
-class Conv2DOpSnippent(Snippet):
+class Conv2DOpSnippet(Snippet):
   __template_name__ = "snippets/conv2d_op.cpp"
   __headers__ = set(['"uTensor/ops/MatrixOps.hpp"'])
 
@@ -686,7 +686,7 @@ class QuantizedFusedConv2DOpMaxpoolSnippet(Snippet):
     self.template_vars["padding"] = padding
     self.template_vars["to_eval"] = to_eval
 
-class Conv2DQuantOpSnippent(Snippet):
+class Conv2DQuantOpSnippet(Snippet):
   __template_name__ = "snippets/qconv2d_op.cpp"
   __headers__ = set(['"uTensor/ops/MatrixOps.hpp"'])
 


### PR DESCRIPTION
1. Fix typo, Snippent => Snippet

    Conv2DOpSnippent => Conv2DOpSnippet
    Conv2DQuantOpSnippent => Conv2DQuantOpSnippet

2. Fix QuantizedFusedConv2DOpMaxpoolSnippet template
 