### PR TITLE
setup: fix deployment of template cpp files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,9 @@ setup(
     author_email="qmalliao@gmail.com",
     license=license,
     packages=find_packages(),
-    include_package_data=True,
-    package_data={"utensor_cgen": ["backend/snippets/templates/*"]},
+    package_dir={'utensor_cgen.backend.utensor.snippets': 'utensor_cgen/backend/utensor/snippets'},
+    package_data={'utensor_cgen.backend.utensor.snippets': ["templates/*/*.cpp",
+                                                            "templates/*/*.hpp"]},
     entry_points={
         "console_scripts": [
             "utensor-cli=utensor_cgen.cli:cli"

--- a/utensor_cgen/backend/utensor/snippets/template_env.py
+++ b/utensor_cgen/backend/utensor/snippets/template_env.py
@@ -1,7 +1,9 @@
 # -*- coding:utf8 -*-
-from jinja2 import Environment, PackageLoader
+import os
+from jinja2 import Environment, FileSystemLoader
 
-_loader = PackageLoader('utensor_cgen', 'backend/utensor/snippets/templates')
+_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates/')
+_loader = FileSystemLoader(searchpath=_dir)
 
 env = Environment(loader=_loader, trim_blocks=True, lstrip_blocks=True)
 env.globals.update(zip=zip)


### PR DESCRIPTION
This PR fixes the deployment of template cpp files in the package generated with pip.

When installing utensor_cgen using pip (like it's documented in the README), the template files are not present and the script crashes when generating the model cpp files.

Also you should not use the `-e` option in the CI setup command:
https://github.com/uTensor/utensor_cgen/blob/6b8ccf3989277f2654155c6dc4f9c8f72723808c/.circleci/config.yml#L9

Just use `pip3 install .` with CI to perform a standard installation like any regular user would do and keep the `-e` option for your local development env.