### PR TITLE
hotfix: reshape op data parser, inferring new shape from input tensors

### DIFF
--- a/utensor_cgen/frontend/tflite.py
+++ b/utensor_cgen/frontend/tflite.py
@@ -59,6 +59,7 @@ class TFLiteParser(Parser):
       ops_info={},
     )
     self._build_graph(fb_model, ugraph)
+    ugraph = self._hotfix_reshape(ugraph)
     ugraph = Legalizer.legalize(ugraph)
     return ugraph
 
@@ -271,6 +272,28 @@ class TFLiteParser(Parser):
   def _format_op_type(self, op_type):
     return ''.join(map(lambda s: s.capitalize(), op_type.split('_')))
 
+  @staticmethod
+  def _hotfix_reshape(ugraph):
+    for op in ugraph.get_ops_by_type("Reshape"):
+      new_shape = op.op_attr["new_shape"]
+      if not new_shape:
+        logger.warning(f'{op.name} has no new_shape as its attributes, using the second input tensor as new shape instead')
+        tensor_new_shape = op.input_tensors.pop(1)
+        op.n_inputs -= 1
+        ori_new_shape = tensor_new_shape.op.op_attr['value'].value.np_array.tolist()
+        new_shape_ = []
+        has_neg = False
+        for s in ori_new_shape:
+          if s < 0:
+            has_neg = True
+            s = abs(s)
+          new_shape_.append(s)
+        if has_neg:
+          logger.warning(f"implicit convert negative shape of reshape op to positive: {ori_new_shape} -> {new_shape_}")
+        op.op_attr["new_shape"] = new_shape_
+      del ugraph.ops_info[tensor_new_shape.op.name]
+    return ugraph
+
 
 # helper functions for parsing op data (will be stored in op_attr)
 def class_option2str(obj, idx):
@@ -353,8 +376,11 @@ def reshape_op_data(op, fb_mdel):
 
     option = ReshapeOptions()
     builtin_data = op.BuiltinOptions()
-    option.Init(builtin_data.Bytes, builtin_data.Pos)
-    option_dict["new_shape"] = list(option.NewShapeAsNumpy())
+    if builtin_data is None:
+      option_dict["new_shape"] = list()
+    else:
+      option.Init(builtin_data.Bytes, builtin_data.Pos)
+      option_dict["new_shape"] = list(option.NewShapeAsNumpy())
   else:
     option_dict[
       _CUSTOM_OPTION_FORMAT_MAP[op.CustomOptionsFormat()]


### PR DESCRIPTION
new shape sometime is input tensor in TFLite model file.
That's why the tflite parser will fail randomly since the op options will be `None` in this case.

<img width="1025" alt="Screen Shot 2020-11-24 at 4 52 46 PM" src="https://user-images.githubusercontent.com/6830390/100070978-8279be00-2e75-11eb-9f77-7971e122c199.png">
