### PR TITLE
MaxPool op in list-support-ops

### DIFF
--- a/utensor_cgen/backend/utensor/code_generator/rearch/_operators/_impls.py
+++ b/utensor_cgen/backend/utensor/code_generator/rearch/_operators/_impls.py
@@ -545,6 +545,7 @@ class _AvgPoolOperator(_PoolingOperatorMixin, _Operator):
 @OperatorFactory.register
 class _MaxPoolOperator(_GenericMaxOperator, _PoolingOperatorMixin):
   namespaces = ('ReferenceOperators',)
+  op_type = 'MaxPoolOperator'
 
   def get_declare_snippet(self, op_var_name, with_const_params=True):
     return DeclareOpSnippet(


### PR DESCRIPTION
Noticed that the MaxPool operator wasn't listed when using list-support-ops.